### PR TITLE
Split postpunct from postcode

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -9982,7 +9982,7 @@
   \def\blx@dlimcode{\multicitedelim}%
   \def\blx@postpunct@saved{#6}%
   \ifblank{#2}
-    {\def\blx@postcode\@empty}
+    {\let\blx@postcode\@empty}
     {\def\blx@postcode{\usebibmacro{postnote}}}%
   \boolfalse{citetracker}%
   \boolfalse{pagetracker}%
@@ -10010,7 +10010,7 @@
   \def\blx@dlimcode{\multicitedelim}%
   \def\blx@postpunct@saved{#6}%
   \ifblank{#2}
-    {\def\blx@postcode\@empty}
+    {\let\blx@postcode\@empty}
     {\def\blx@postcode{\usebibmacro{postnote}}}%
   \boolfalse{citetracker}%
   \boolfalse{pagetracker}%
@@ -10039,7 +10039,7 @@
   \def\blx@dlimcode{\multicitedelim}%
   \def\blx@postpunct@saved{#6}%
   \ifblank{#2}
-    {\def\blx@postcode\@empty}
+    {\let\blx@postcode\@empty}
     {\def\blx@postcode{\usebibmacro{postnote}}}%
   \boolfalse{citetracker}%
   \boolfalse{pagetracker}%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -9717,8 +9717,8 @@
     \def\blx@precode{\delimcontext{#1}#2}%
     \def\blx@loopcode{#3}%
     \def\blx@dlimcode{#4}%
-    \def\blx@postpunct@saved{##4}%
     \def\blx@postcode{#5}%
+    \def\blx@postpunct@saved{##4}%
     \blx@citeloop{##3}%
     \endgroup}}
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -8914,6 +8914,8 @@
     \ifnum\blx@tempcntb>\z@
       \multicitedelim
     \fi
+  \else
+    \blx@postpunct@saved
   \fi
   % \blx@tempb is a sorted list of all cites, \blx@tempa is the list of cites to
   % sort using this list
@@ -9057,6 +9059,7 @@
   \ifnum\c@citecount=\c@citetotal
     \def\blx@thecheckpunct{\blx@err@nestcite\@gobble}%
     \blx@postcode
+    \blx@postpunct@saved
   \fi
   \blx@endlangcite
   \endgroup
@@ -9714,7 +9717,8 @@
     \def\blx@precode{\delimcontext{#1}#2}%
     \def\blx@loopcode{#3}%
     \def\blx@dlimcode{#4}%
-    \def\blx@postcode{#5##4}%
+    \def\blx@postpunct@saved{##4}%
+    \def\blx@postcode{#5}%
     \blx@citeloop{##3}%
     \endgroup}}
 
@@ -9976,9 +9980,10 @@
        \abx@missing{#5}}
       {\printnames[#4]{#5}}}%
   \def\blx@dlimcode{\multicitedelim}%
+  \def\blx@postpunct@saved{#6}%
   \ifblank{#2}
-    {\def\blx@postcode{#6}}
-    {\def\blx@postcode{\usebibmacro{postnote}#6}}%
+    {\def\blx@postcode\@empty}
+    {\def\blx@postcode{\usebibmacro{postnote}}}%
   \boolfalse{citetracker}%
   \boolfalse{pagetracker}%
   \blx@citeloop{#3}%
@@ -10003,9 +10008,10 @@
        \abx@missing{#5}}
       {\printlist[#4]{#5}}}%
   \def\blx@dlimcode{\multicitedelim}%
+  \def\blx@postpunct@saved{#6}%
   \ifblank{#2}
-    {\def\blx@postcode{#6}}
-    {\def\blx@postcode{\usebibmacro{postnote}#6}}%
+    {\def\blx@postcode\@empty}
+    {\def\blx@postcode{\usebibmacro{postnote}}}%
   \boolfalse{citetracker}%
   \boolfalse{pagetracker}%
   \blx@citeloop{#3}%
@@ -10031,9 +10037,10 @@
        \abx@missing{#5}}
       {\printfield[#4]{#5}}}%
   \def\blx@dlimcode{\multicitedelim}%
+  \def\blx@postpunct@saved{#6}%
   \ifblank{#2}
-    {\def\blx@postcode{#6}}
-    {\def\blx@postcode{\usebibmacro{postnote}#6}}%
+    {\def\blx@postcode\@empty}
+    {\def\blx@postcode{\usebibmacro{postnote}}}%
   \boolfalse{citetracker}%
   \boolfalse{pagetracker}%
   \blx@citeloop{#3}%


### PR DESCRIPTION
This came up in https://tex.stackexchange.com/q/334839/35864 a detailed analysis of what happens can be found in my answer there.

`biblatex` would gobble the postpunct after a cite command with only undefined citations. This is essentially due to the fact that both the postpunct and the general postcode of a citation command live in the same macro that is executed after a citation is processed. This command can not be (and is not) called after undefined citations. So for postpunct to work it needed to be split apart from the general postcode macro. This is what this pull request does.

Since this PR modifies low-level commands testing is needed. My manual tests as well as the OP's tests revealed no problems so far. Potential issue with this is that by splitting the postpunct from the postcode macro we cement the order of execution of postcode first, then postpunct, that was only implicit before. But I don't think that should be a problem.